### PR TITLE
カテゴリのjson表記を修正

### DIFF
--- a/README.ja_JP.md
+++ b/README.ja_JP.md
@@ -207,7 +207,7 @@ Mega list compiled from a variety to sources. Also available here: http://www.ma
 * Which parts of your project are unclear or confusing?
 
 
-## その他
+## Other 
 * As a kid, what did you want to be when you grew up?
 * How are things going for you outside of work?
 * If you had millions of dollars, what would you do every day?

--- a/README.ja_JP.md
+++ b/README.ja_JP.md
@@ -207,7 +207,7 @@ Mega list compiled from a variety to sources. Also available here: http://www.ma
 * Which parts of your project are unclear or confusing?
 
 
-## Other 
+## その他
 * As a kid, what did you want to be when you grew up?
 * How are things going for you outside of work?
 * If you had millions of dollars, what would you do every day?

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Mega list compiled from a variety to sources. Also available here: http://www.ma
 * Which parts of your project are unclear or confusing?
 
 
-## Other 
+## Other
 * As a kid, what did you want to be when you grew up?
 * How are things going for you outside of work?
 * If you had millions of dollars, what would you do every day?

--- a/questions.json
+++ b/questions.json
@@ -5,24 +5,31 @@
   ],
   "i18nCategories": {
     "About Manager": {
+      "en": "About Manager",
       "ja_JP": "マネージャについて"
     },
     "Career development": {
+      "en": "Career development",
       "ja_JP": "キャリア開発"
     },
     "Conversation starters": {
+      "en": "Conversation starters",
       "ja_JP": "会話のきっかけ"
     },
     "Job satisfaction": {
+      "en": "Job satisfaction",
       "ja_JP": "働きがい"
     },
-    "Other ": {
+    "Other": {
+      "en": "Other",
       "ja_JP": "その他"
     },
     "Team and company": {
+      "en": "Team and company",
       "ja_JP": "チームと会社"
     },
     "Work-life": {
+      "en": "Work-life",
       "ja_JP": "ワーク・ライフ"
     }
   },

--- a/questions.json
+++ b/questions.json
@@ -1970,7 +1970,7 @@
         "en": "What\u2019s one thing we could change about work for you that would improve your personal life?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.031Z",
       "updated_at": "2017-11-18T14:26:15.031Z"
     },
@@ -1980,7 +1980,7 @@
         "en": "What did you do for fun in the past that you haven\u2019t had as much time for lately?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.043Z",
       "updated_at": "2017-11-18T14:26:15.043Z"
     },
@@ -1990,7 +1990,7 @@
         "en": "As a kid, what did you want to be when you grew up?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.046Z",
       "updated_at": "2017-11-18T14:26:15.046Z"
     },
@@ -2000,7 +2000,7 @@
         "en": "If you had millions of dollars, what would you do every day?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.048Z",
       "updated_at": "2017-11-18T14:26:15.048Z"
     },
@@ -2010,7 +2010,7 @@
         "en": "What questions do you have about the project?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.060Z",
       "updated_at": "2017-11-18T14:26:15.060Z"
     },
@@ -2020,7 +2020,7 @@
         "en": "What ideas can you bring in from past successes?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.062Z",
       "updated_at": "2017-11-18T14:26:15.062Z"
     },
@@ -2030,7 +2030,7 @@
         "en": "What haven\u2019t you tried yet?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.065Z",
       "updated_at": "2017-11-18T14:26:15.065Z"
     },
@@ -2040,7 +2040,7 @@
         "en": "What would you be doing right now if we weren\u2019t having this meeting? How do you feel about being taken away from that task?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.067Z",
       "updated_at": "2017-11-18T14:26:15.067Z"
     },
@@ -2050,7 +2050,7 @@
         "en": "How are things going for you outside of work?",
         "ja_JP": ""
       },
-      "category": "Other ",
+      "category": "Other",
       "created_at": "2017-11-18T14:26:15.081Z",
       "updated_at": "2017-11-18T14:26:15.081Z"
     },


### PR DESCRIPTION
`index.js` 内のコメントに

```
Why is there also a JSON file?
- it can be directly consumed by apps
```

とあり、アプリから直接利用をするのであれば、やはりカテゴリは正規化したほうがよろしかろうと思ったので、修正するPRです。

また、カテゴリの `Other` の末尾にスペースがついていたため、日本語版のREADMEが `その他` と表示されていなかった不具合を修正しました。

２つのことを一つのPRで処理してもうしわけないです 🙇 
